### PR TITLE
Fix unexpected keyword argument error

### DIFF
--- a/src/gitagent/claude_code_sdk_executor.py
+++ b/src/gitagent/claude_code_sdk_executor.py
@@ -134,8 +134,9 @@ class ClaudeCodeSDKExecutor:
                 options_dict["system_prompt"] = agent.configuration["system_prompt"]
             if "append_system_prompt" in agent.configuration:
                 options_dict["append_system_prompt"] = agent.configuration["append_system_prompt"]
-            if "temperature" in agent.configuration:
-                options_dict["temperature"] = agent.configuration["temperature"]
+            # Note: temperature is not supported by ClaudeCodeOptions
+            # if "temperature" in agent.configuration:
+            #     options_dict["temperature"] = agent.configuration["temperature"]
             if "max_tokens" in agent.configuration:
                 options_dict["max_tokens"] = agent.configuration["max_tokens"]
         


### PR DESCRIPTION
Remove `temperature` parameter from `ClaudeCodeOptions` initialization to fix an `unexpected keyword argument` error.

The `claude-code-sdk`'s `ClaudeCodeOptions` class does not accept a `temperature` parameter, leading to an initialization error when it was passed. This change comments out the problematic line and adds a note for clarity.